### PR TITLE
Update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 bower_components
+package-lock.json

--- a/bin/cave
+++ b/bin/cave
@@ -11,7 +11,7 @@ var ok;
 if (argv.css) {
   go(read(argv.css));
 } else {
-  stdin(go);
+  stdin.then(go);
   setTimeout(die, 100);
 }
 

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
   },
   "dependencies": {
     "css": "^2.1.0",
-    "get-stdin": "^3.0.0",
-    "lodash": "^2.4.1",
-    "minimist": "^1.1.0"
+    "get-stdin": "^6.0.0",
+    "lodash": "^4.17.11",
+    "minimist": "^1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cave",
   "description": "Remove critical CSS from your stylesheet after inlining it in your pages",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "homepage": "https://github.com/bevacqua/cave",
   "author": {
     "name": "Nicolas Bevacqua",

--- a/src/cave.js
+++ b/src/cave.js
@@ -23,8 +23,8 @@ function api (stylesheet, options) {
     if (inspected.type === 'rule') {
       if (parent) {
         _(sheetRules)
-          .where({ type: 'media', media: parent.media })
-          .pluck('rules')
+          .filter({ type: 'media', media: parent.media })
+          .map('rules')
           .value()
           .forEach(removeMatches);
       } else {


### PR DESCRIPTION
The main reason for this PR is to update `lodash`, because of [this](https://nodesecurity.io/advisories/577) vulnerability found on `lodash < 4.17.5` that was really bugging me, but I also took the time to update `minimist` and `get-stdin` and make the appropriate changes to keep everything working.